### PR TITLE
NOJ - Split file - fixing arch package

### DIFF
--- a/build-aux/arch/gohip-bin/PKGBUILD
+++ b/build-aux/arch/gohip-bin/PKGBUILD
@@ -1,3 +1,4 @@
+pkgver=0.3.4
 _packager="Romain Gallet <romain_gallet_at_gmail_com"
 _deb_pkgname=gohip
 pkgname=gohip-bin
@@ -25,4 +26,6 @@ build() {
 
 package() {
 	cp -fr usr/ ${pkgdir}
+	cp -fr etc/ ${pkgdir}
 }
+sha256sums=('18b0e682921661a5138f2c1e0c5f2163086c374d49980debeb2dbc849f791c26')


### PR DESCRIPTION
Why
===

split script file was missing from arch archive