### PR TITLE
NOJ - split file - change config file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Download and install `gohip` from the [releases page](https://github.com/bechamp
 
 # Usage
 
-Create a file in your home directory called `.splitvpn` with the following content:
+Create file `/etc/vpnc/splitvpn` with the following content:
 
     MAIN_DEV="enp0s31f6" # Your main network interface
     GW="192.168.1.254"   # Your gateway
 
 You can determine those values with
 
-    ip -json r get 1.1.1.1 | jq '.[]| "DEV=\"\(.dev)\" \nGW=\"\(.gateway)\""' -r
+    ip -json r get 1.1.1.1 | jq '.[]| "MAIN_DEV=\"\(.dev)\" \nGW=\"\(.gateway)\""' -r
 
 Then start the vpn client with
 

--- a/build-aux/scripts/split.sh
+++ b/build-aux/scripts/split.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-if [[ ! -f $HOME/.splitvpn ]]; then
-    echo "$HOME/.splitvpn does exist. Please create it with the following content:"
+CONFIG_FILE=/etc/vpnc/splitvpn
+
+if [[ ! -f $CONFIG_FILE ]]; then
+    echo "$CONFIG_FILE does exist. Please create it with the following content:"
 cat << EOF
 
 # beginning
@@ -12,13 +14,13 @@ GW="192.168.1.254"   # Your gateway
 # end
 
 You can determine those values with
-  ip -json r get 1.1.1.1 | jq '.[]| "DEV=\"\(.dev)\" \nGW=\"\(.gateway)\""' -r
+  ip -json r get 1.1.1.1 | jq '.[]| "MAIN_DEV=\"\(.dev)\" \nGW=\"\(.gateway)\""' -r
 
 EOF
     exit 1
 fi
 
-. ${HOME}/.splitvpn
+. $CONFIG_FILE
 
 DISNEY_NET="10/8"
 VPN_DEV="tun0"


### PR DESCRIPTION
Why
===

Command runs with `sudo`. Much easier if file not located in `/root/`