### PR TITLE
NOJ - include both dynamic & static binary gohip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,26 +29,13 @@ jobs:
           RELEASE_VERSION=$(echo ${{ github.ref }} | tr -d 'refs/tags/v')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/') # redundant, but just to be sure
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: gohip-linux-amd64
-          asset_path: ./gohip-linux-amd64
-          asset_content_type: application/octet-stream
+          files: |
+            gohip-linux-amd64
+            gohip-static-linux-amd64
 
       - name: Create Debian package
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,26 @@ jobs:
           RELEASE_VERSION=$(echo ${{ github.ref }} | tr -d 'refs/tags/v')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/') # redundant, but just to be sure
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: |
-            gohip-linux-amd64
-            gohip-static-linux-amd64
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_name: gohip-linux-amd64
+          asset_path: ./gohip-linux-amd64
+          asset_content_type: application/octet-stream
 
       - name: Create Debian package
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-CGO_ENABLED=0
-export CGO_ENABLED
 all: delete_latest_tag recreate_tag push_tag
 
 delete_latest_tag:
@@ -16,15 +14,21 @@ push_tag:
 
 .PHONY: all delete_latest_tag recreate_tag push_tag
 
-build: test
-	go build -o gohip-$(GOOS)-$(GOARCH)
-
 test:
 	go test -v ./systemd ./others ./osdata ./types .
+
+build: build-dynamic build-static
+
+build-dynamic:
+	go build -o gohip-$(GOOS)-$(GOARCH)
+
+build-static:
+	CGO_ENABLED=0 go build -o gohip-static-$(GOOS)-$(GOARCH)
 
 install: build
 	mkdir -p $(DESTDIR)/usr/bin
 	cp gohip-$(GOOS)-$(GOARCH) $(DESTDIR)/usr/bin/gohip
+	cp gohip-static-$(GOOS)-$(GOARCH) $(DESTDIR)/usr/bin/gohip-static
 
 debian-pkg: install
 	mkdir -p $(DESTDIR)/DEBIAN


### PR DESCRIPTION
Why
====

Some users are running on glibc < `2.32`. In this event, the package version is to provide a static binary as well.

What
=====

Dynamic binary is (still) called `gohip`. Static one is `gohip-static`. Both can be found from releases page.
