### PR TITLE
NOJ - Using softprops/action-gh-release@v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,26 +29,13 @@ jobs:
           RELEASE_VERSION=$(echo ${{ github.ref }} | tr -d 'refs/tags/v')
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/') # redundant, but just to be sure
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: gohip-linux-amd64
-          asset_path: ./gohip-linux-amd64
-          asset_content_type: application/octet-stream
+          files: |
+            gohip-linux-amd64
+            gohip-static-linux-amd64
 
       - name: Create Debian package
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} RELEASE_VERSION=$RELEASE_VERSION DESTDIR=$DESTDIR make debian-pkg
 
       - name: Upload Debian release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
@@ -71,7 +71,7 @@ jobs:
           md5sum gohip-$RELEASE_VERSION-1.x86_64.rpm >> gohip-$RELEASE_VERSION-1.x86_64.rpm
 
       - name: Upload CentOS 8 release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
@@ -111,7 +111,7 @@ jobs:
           md5sum build-aux/arch/gohip-bin/gohip-bin-$RELEASE_VERSION-1-x86_64.pkg.tar.zst >> build-aux/arch/gohip-bin/gohip-bin-$RELEASE_VERSION-1-x86_64.pkg.tar.zst.md5sum
 
       - name: Upload Arch Linux release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |


### PR DESCRIPTION
Why
====

[`actions/create-release@v1`](https://github.com/actions/create-release) is deprecated
