### PR TITLE
NOJ - added bash guards

### DIFF
--- a/build-aux/scripts/split.sh
+++ b/build-aux/scripts/split.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+if [ -z "$BASH" ]; then echo "Please run this script $0 with bash"; exit; fi
+
 CONFIG_FILE=/etc/vpnc/splitvpn
 RUNNING_FROM_OPENCONNECT=false
 


### PR DESCRIPTION
Why
====

Some users, mostly linux mint users, have their default shell set to dash, which is pure POSIX. The `split.sh` is _not_ POSIX.