### PR TITLE
Support breaking CLI arg changes from gpclient

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ func main() {
 	logCommandAndArgs()
 	cookie := flag.String("cookie", "", "")
 	_ = flag.String("client-os", "", "")
+	_ = flag.String("client-version", "", "")
+	_ = flag.String("os-version", "", "")
 	clientip := flag.String("client-ip", "", "")
 	md5 := flag.String("md5", "", "")
 	flag.Parse()


### PR DESCRIPTION
Version 2.5.1 of gpclient now sends `client-version` and `os-version` arguments. Go's `flag` package treats unknown arguments as errors, so we need to explicitly handle these new arguments.