### PR TITLE
Ignore `host-id` argument during arg parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	_ = flag.String("client-os", "", "")
 	_ = flag.String("client-version", "", "")
 	_ = flag.String("os-version", "", "")
+	_ = flag.String("host-id", "", "")
 	clientip := flag.String("client-ip", "", "")
 	md5 := flag.String("md5", "", "")
 	flag.Parse()


### PR DESCRIPTION
Latest `gpclient` release adds a `-host-id` argument, which is unrecognized by the current arg parser and breaks `gohip`. This is a tiny, targeted fix to keep things working.